### PR TITLE
Handle concurrent requests for users

### DIFF
--- a/src/user-service.ts
+++ b/src/user-service.ts
@@ -52,7 +52,7 @@ export class UserService implements UserServiceInterface {
 
   /** @inheritdoc */
   async getLoggedInUser(): Promise<Result<UserInterface, UserServiceError>> {
-    // if the user doesn't have IA cookies, don't bother checking
+    // if the user doesn't have IA cookies, just return a `userNotLoggedIn` error
     const hasCookies = await this.hasArchiveOrgLoggedInCookies();
     if (!hasCookies)
       return {
@@ -66,7 +66,7 @@ export class UserService implements UserServiceInterface {
       return { success: user };
     }
 
-    // if another fetch is in line, chain it
+    // if another fetch is in progress, chain this request to it
     if (this.fetchPromise) {
       this.fetchPromise = this.fetchPromise.then(response => {
         return response;
@@ -74,9 +74,9 @@ export class UserService implements UserServiceInterface {
       return this.fetchPromise;
     }
 
-    // execute the first fetch
+    // assign the fetch promise so chaining starts
     this.fetchPromise = this.fetchUser();
-    // get the result
+    // fetch the result
     const result = await this.fetchPromise;
     // reset it so subsequent requests go through normal flow
     this.fetchPromise = undefined;

--- a/src/user-service.ts
+++ b/src/user-service.ts
@@ -52,18 +52,40 @@ export class UserService implements UserServiceInterface {
 
   /** @inheritdoc */
   async getLoggedInUser(): Promise<Result<UserInterface, UserServiceError>> {
+    // if the user doesn't have IA cookies, don't bother checking
     const hasCookies = await this.hasArchiveOrgLoggedInCookies();
     if (!hasCookies)
       return {
         error: new UserServiceError(UserServiceErrorType.userNotLoggedIn),
       };
 
+    // check for cached user
     const persistedUser = await this.getPersistedUser();
     if (persistedUser) {
       const user = User.fromUserResponse(persistedUser);
       return { success: user };
     }
 
+    // if another fetch is in line, chain it
+    if (this.fetchPromise) {
+      this.fetchPromise = this.fetchPromise.then(response => {
+        return response;
+      });
+      return this.fetchPromise;
+    }
+
+    // execute the first fetch
+    this.fetchPromise = this.fetchUser();
+    // get the result
+    const result = await this.fetchPromise;
+    // reset it so subsequent requests go through normal flow
+    this.fetchPromise = undefined;
+    return result;
+  }
+
+  private fetchPromise?: Promise<Result<UserInterface, UserServiceError>>;
+
+  private async fetchUser(): Promise<Result<UserInterface, UserServiceError>> {
     let response: Response;
     try {
       response = await fetch(this.userServiceEndpoint, {

--- a/test/user-service.test.ts
+++ b/test/user-service.test.ts
@@ -111,7 +111,7 @@ describe('UserService', () => {
       expect(result.error?.type).to.equal(UserServiceErrorType.decodingError);
     });
 
-    it('only allows a single request at a time', async () => {
+    it('chains concurrent requests into a single fetch', async () => {
       cookieStoreStub?.returns('fake-ia-cookie');
       fetchStub?.returns(getSuccessResponse());
 
@@ -128,6 +128,7 @@ describe('UserService', () => {
         userService.getLoggedInUser(),
       ]);
 
+      // 4 concurrent requests will only make a single fetch
       expect(fetchStub?.callCount).to.equal(1);
 
       // validate all of the results got populated properly
@@ -143,6 +144,7 @@ describe('UserService', () => {
       cookieStoreStub?.returns('fake-ia-cookie');
       fetchStub?.returns(getSuccessResponse());
 
+      // don't use the cache so we can verify fetch behavior
       const userService = new UserService();
 
       await Promise.all([
@@ -152,6 +154,9 @@ describe('UserService', () => {
         userService.getLoggedInUser(),
       ]);
       expect(fetchStub?.callCount).to.equal(1);
+
+      // after the concurrent requests finish, since we don't have a cache,
+      // another fetch gets made
       await userService.getLoggedInUser();
       expect(fetchStub?.callCount).to.equal(2);
     });


### PR DESCRIPTION
Previously if two concurrent requests came in before one was cached, we would fire off two requests to the backend. Now we chain the requests so only one ever happens at a time.